### PR TITLE
Update IN-Chapter to IT-Chapter and songlist link

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -42,6 +42,6 @@ jobs:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USERNAME }}
           key: ${{ secrets.SSH_KEY }}
-          port: 2222
+          port: 22
           envs: GITHUB_TOKEN,GITHUB_ACTOR
-          script: "cd songbook-2.0 && echo $GITHUB_TOKEN | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin && docker compose up -d"
+          script: 'cd songbook-2.0 && echo $GITHUB_TOKEN | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin && docker compose up -d'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The IN-Chapters Webapp Songbook 2.0
+# The IT-Chapters Webapp Songbook 2.0
 
 The chapters new and improved songbook (PWA) webapp!
 
@@ -45,14 +45,13 @@ To keep track of what work needs to/should be done, what is being done and what 
 All commits should include either `Related to #X` to or `Resolves #X` in the commit message. As in the following example:
 
 ```
+Add some feature
 
-Adds some feature
+Add this
+Remove that
+Update something
 
-Adds this
-Removes that
-Updates something
-
-Resolves #13
+Resolve #13
 ```
 
 This is done to make reading the history easy and understanding what the purspose of each commit was.

--- a/index.html
+++ b/index.html
@@ -7,11 +7,8 @@
 			content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
 		/>
 		<meta name="theme-color" content="#2e5163" />
-		<title>IN-Songbook</title>
-		<meta
-			name="description"
-			content="Song book for the Chapter of Information and Nanotechnology"
-		/>
+		<title>IT-Songbook</title>
+		<meta name="description" content="Song book for the Chapter of Information Technology" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<link rel="icon" href="/favicon.ico" />
 		<link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="180x180" />

--- a/src/definitions/songs.ts
+++ b/src/definitions/songs.ts
@@ -20,4 +20,4 @@ export type SongsWithMeta = {
 };
 
 export const SONGS_JSON_URL =
-	'https://raw.githubusercontent.com/insektionen/songlist/master/dist/songs.json';
+	'https://raw.githubusercontent.com/itsektionen/songlist/master/dist/songs.json';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,9 +24,9 @@ export default defineConfig({
 		VitePWA({
 			registerType: 'autoUpdate',
 			manifest: {
-				name: 'IN-Songbook',
+				name: 'IT-Songbook',
 				short_name: 'Songbook',
-				description: 'The IN-Chapters Webapp Songbook 2.0',
+				description: 'The IT-Chapters Webapp Songbook 2.0',
 				theme_color: '#2e5163',
 				icons: [
 					{
@@ -46,7 +46,7 @@ export default defineConfig({
 					getCache({
 						name: 'songs.json',
 						pattern:
-							'https://raw.githubusercontent.com/insektionen/songlist/master/dist/songs.json',
+							'https://raw.githubusercontent.com/itsektionen/songlist/master/dist/songs.json',
 					}),
 				],
 				globPatterns: ['**/*.{js,css,html}', '*', 'assets/*'],


### PR DESCRIPTION
Updates in line with the chapter renaming from the Chapter for Information and Nanotechnology to Chapter for Information Technology.
- Update all mentions of the IN-Chapter to the IT-Chapter.
- Fix the songlist link from `github.com/insektionen/...` to `github.com/itsektionen/...` to correctly get the songs even after GitHub renaming.
- Fix the deployment script to ssh port `22` instead of `2222`
- Fix the README commit message format in line with all commits.

Resolves #46  